### PR TITLE
fix(matchers): missing people.length in hasLength example

### DIFF
--- a/src/content/docs/testing/testing.mdx
+++ b/src/content/docs/testing/testing.mdx
@@ -121,7 +121,7 @@ Now, we are explicitly testing that we have accessed the `onTap` property of `So
   <TabItem label="Good ✅">
     ```dart
     expect(name, equals('Hank'));
-    expect(people, hasLength(3));
+    expect(people.length, hasLength(3));
     expect(valid, isTrue);
     ```
 


### PR DESCRIPTION
# Description

Seems like calling `length` getter was missing in hasLength matcher example.