### PR TITLE
fix: flutter_localizations typo

### DIFF
--- a/src/content/docs/internationalization/localization.mdx
+++ b/src/content/docs/internationalization/localization.mdx
@@ -27,7 +27,7 @@ Internationalization is often referred as i18n and localization as l10n since th
 
 We can use Flutter's built-in support for localization.
 
-1. Start by setting up internationalization. In Flutter, you will have to install the `fluter_localizations` and `intl` packages. Also, enable the `generate` flag in the `flutter` section of the pubspec file:
+1. Start by setting up internationalization. In Flutter, you will have to install the `flutter_localizations` and `intl` packages. Also, enable the `generate` flag in the `flutter` section of the pubspec file:
 
 ```yaml
 flutter:


### PR DESCRIPTION
`fluter_localizations` => `flutter_localizations`