### PR TITLE
feat: add routes for llms.txt and llms-full.txt

### DIFF
--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -4,12 +4,12 @@ import type { APIRoute } from "astro";
 const docs = await getCollection("docs");
 
 export const GET: APIRoute = async () => {
-    return new Response(
-        `# Very Good Engineering Full Documentation\n\n${docs
-            .map((doc) => {
-                return `# ${doc.data.title}\n\n${doc.body}\n\n`;
-            })
-            .join("")}`,
-        { headers: { "Content-Type": "text/plain; charset=utf-8" } }
-    );
+  return new Response(
+    `# Very Good Engineering Full Documentation\n\n${docs
+      .map((doc) => {
+        return `# ${doc.data.title}\n\n${doc.body}\n\n`;
+      })
+      .join("")}`,
+    { headers: { "Content-Type": "text/plain; charset=utf-8" } },
+  );
 };

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,0 +1,15 @@
+import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
+
+const docs = await getCollection("docs");
+
+export const GET: APIRoute = async () => {
+    return new Response(
+        `# Very Good Engineering Full Documentation\n\n${docs
+            .map((doc) => {
+                return `# ${doc.data.title}\n\n${doc.body}\n\n`;
+            })
+            .join("")}`,
+        { headers: { "Content-Type": "text/plain; charset=utf-8" } }
+    );
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,15 @@
+import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
+
+const docs = await getCollection("docs");
+
+export const GET: APIRoute = async () => {
+    return new Response(
+        `# Very Good Engineering Documentation\n\n${docs
+            .map((doc) => {
+                return `- [${doc.data.title}](https://engineering.verygood.ventures/${doc.slug}/)\n`;
+            })
+            .join("")}`,
+        { headers: { "Content-Type": "text/plain; charset=utf-8" } }
+    );
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -4,12 +4,12 @@ import type { APIRoute } from "astro";
 const docs = await getCollection("docs");
 
 export const GET: APIRoute = async () => {
-    return new Response(
-        `# Very Good Engineering Documentation\n\n${docs
-            .map((doc) => {
-                return `- [${doc.data.title}](https://engineering.verygood.ventures/${doc.slug}/)\n`;
-            })
-            .join("")}`,
-        { headers: { "Content-Type": "text/plain; charset=utf-8" } }
-    );
+  return new Response(
+    `# Very Good Engineering Documentation\n\n${docs
+      .map((doc) => {
+        return `- [${doc.data.title}](https://engineering.verygood.ventures/${doc.slug}/)\n`;
+      })
+      .join("")}`,
+    { headers: { "Content-Type": "text/plain; charset=utf-8" } },
+  );
 };


### PR DESCRIPTION
Closes #97 . Adds two new routes: `/llms.txt` and `/llms-full.txt`. `llms.txt` displays links to every article, whereas `llms-full.txt` returns the text for every single article. This is used for AI tools to better answer questions.