### PR TITLE
docs: fix minor typo in CI/CD documentation

### DIFF
--- a/src/content/docs/automation/ci_cd.mdx
+++ b/src/content/docs/automation/ci_cd.mdx
@@ -65,7 +65,7 @@ Check out some workflow examples we've used in projects like [I/O Crossword][cro
 
 ### GitLab CI/CD
 
-[GitLab CI/CD][gitlab_ci_cd] is the official CI/CD platform for GitLab. They offer a similar set of features as GitHub Actions, enabling us to can apply the practices we've discussed above.
+[GitLab CI/CD][gitlab_ci_cd] is the official CI/CD platform for GitLab. They offer a similar set of features as GitHub Actions, enabling us to apply the practices we've discussed above.
 
 ---
 


### PR DESCRIPTION
It seems that an extra "can" made it to this sentence.