### PR TITLE
fix(backend): update to correct dart frog links

### DIFF
--- a/src/content/docs/architecture/backend.mdx
+++ b/src/content/docs/architecture/backend.mdx
@@ -10,12 +10,12 @@ Loose coupling, separation of concerns and layered architecture should not only 
 :::note
 There are many languages and frameworks to write backends in. It is important to choose tools and follow patterns that serve business needs and maximize developer efficiency. VGV built [Dart Frog](https://dart-frog.dev/) for this purpose. Dart Frog provides a number of advantages to developers writing Flutter apps:
 
-- Writing Dart code in both backend and frontend limits developer context switching and allows model reuse throughout the project
-- Dart Frog's minimalistic design allows for flexibility and customization to suit individual app needs
-- [Providers](https://dart-frog.dev/docs/basics/dependency-injection) and [middleware](https://dart-frog.dev/docs/basics/middleware) allow for easy dependency injection
-- File-based [routing](https://dart-frog.dev/docs/basics/routes) makes endpoint creation simple
-- All backend code is [easily testable](https://dart-frog.dev/docs/basics/testing)
-- Access to features such as Dart dev tools and hot reload speed development time
+- Writing Dart code in both backend and frontend limits developer context switching and allows model reuse throughout the project.
+- Dart Frog's minimalistic design allows for flexibility and customization to suit individual app needs.
+- [Providers](https://dart-frog.dev/basics/dependency-injection/) and [middleware](https://dart-frog.dev/basics/middleware/) allow for easy dependency injection.
+- File-based [routing](https://dart-frog.dev/basics/routes/) makes endpoint creation simple.
+- All backend code is [easily testable](https://dart-frog.dev/basics/testing/).
+- Access to features such as Dart dev tools and hot reload speed development time.
 
 :::
 
@@ -81,7 +81,7 @@ final class GetTodosResponse {
 ```
 
 :::note
-It is also advisable to automate JSON serialization inside the models package. This can be achieved with the [json_serializable](https://pub.dev/packages/json_serializable) package, though experimental [macros](https://dart.dev/language/macros) in Dart offer a potentially cleaner way of doing this in the future.
+It is also advisable to automate JSON serialization inside the models package. This can be achieved with the [json_serializable](https://pub.dev/packages/json_serializable) package.
 :::
 
 ### Data Access


### PR DESCRIPTION
Fixing URL changes to Dart Frog documentation links (not sure why this wasn't catch by the md links checker).

Removed reference to macros since they won't be worked on from now on.